### PR TITLE
Fix markup typo

### DIFF
--- a/docs/_writing-tests/css-metadata.md
+++ b/docs/_writing-tests/css-metadata.md
@@ -166,6 +166,7 @@ href="http://www.w3.org/TR/CSS21/colors.html#background-properties" />
 
 
 Example 1 (one token applies):
+
 ``` html
 <meta name="flags" content="invalid" />
 ```


### PR DESCRIPTION
Although it looked fine with the github markdown renderer, the markdown renderer used by jekyll expects an empty line above a code block, and otherwise dumps it into the previous paragraph.