### PR TITLE
Highlight best practice for test assertions

### DIFF
--- a/docs/_writing-tests/css-metadata.md
+++ b/docs/_writing-tests/css-metadata.md
@@ -201,7 +201,8 @@ The assertion should not be:
 * A line or reference from the CSS specification unless that line is
   a complete assertion when taken out of context.
 
-The test assertion is **optional**. It helps the reviewer understand
+The test assertion is **optional**, but is is highly recommended to include one.
+It helps the reviewer understand
 the goal of the test so that he or she can make sure it is being
 tested correctly. Also, in case a problem is found with the test
 later, the testing method (e.g. using `color` to determine pass/fail)


### PR DESCRIPTION
Having an assertion is optional, so documenting it as such is expected. However test reviewers and maintainers highly prefer when there is one, so the documentation should say so.